### PR TITLE
feat(libs): Add initial package `@libs/asset` with fonts

### DIFF
--- a/.changeset/eleven-melons-relate.md
+++ b/.changeset/eleven-melons-relate.md
@@ -1,0 +1,5 @@
+---
+"@libs/asset": minor
+---
+
+✨ Add font assets for: `font-mono`, `font-sans` and `font-serif` design tokens

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,8 +1,8 @@
 [
 	{
 		"name": "@apps/api",
-		"path": "./apps/api/build/main.js",
-		"limit": "3 MB"
+		"path": "./apps/api/build/**/*.js",
+		"limit": "1 MB"
 	},
 	{
 		"name": "@apps/client",
@@ -12,8 +12,13 @@
 	},
 	{
 		"name": "@apps/landing",
-		"path": "./apps/landing/build/",
+		"path": "./apps/landing/build/**/*.html",
 		"limit": "1 s"
+	},
+	{
+		"name": "@libs/asset",
+		"path": "./libs/asset/dist/**/*.js",
+		"limit": "1 kB"
 	},
 	{
 		"name": "@libs/config",
@@ -48,11 +53,11 @@
 	{
 		"name": "@libs/token",
 		"path": "./libs/token/dist/**/*.js",
-		"limit": "3 kB"
+		"limit": "5 kB"
 	},
 	{
 		"name": "@libs/ui",
-		"path": "./libs/ui/dist/**/*.js",
+		"path": "./libs/ui/dist/**/*",
 		"limit": "15 kB"
 	},
 	{

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,3 +1,10 @@
+// @ts-ignore - Intentional. To avoid overhead of including all of the apps & libs at the root.
+import "../libs/asset/src/font/mono";
+// @ts-ignore - Intentional. To avoid overhead of including all of the apps & libs at the root.
+import "../libs/asset/src/font/sans";
+// @ts-ignore - Intentional. To avoid overhead of including all of the apps & libs at the root.
+import "../libs/asset/src/font/serif";
+
 import type { Preview } from "@storybook/svelte";
 
 const preview: Preview = {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -39,13 +39,13 @@
 		"test:unit": "vitest run --dir \"./src\" --passWithNoTests --typecheck"
 	},
 	"devDependencies": {
-		"@fontsource/fira-mono": "5.0.8",
 		"@inlang/paraglide-js-adapter-sveltekit": "0.4.1",
 		"@neoconfetti/svelte": "2.2.1",
 		"@sveltejs/adapter-auto": "3.1.1",
 		"@sveltejs/kit": "2.5.0"
 	},
 	"dependencies": {
+		"@libs/asset": "workspace:*",
 		"@libs/i18n": "workspace:*"
 	}
 }

--- a/apps/client/src/routes/+layout.svelte
+++ b/apps/client/src/routes/+layout.svelte
@@ -1,4 +1,8 @@
 <script>
+	import "@libs/asset/font/sans";
+	import "@libs/asset/font/serif";
+	import "@libs/asset/font/mono";
+
 	import { ParaglideJS } from "@inlang/paraglide-js-adapter-sveltekit";
 	import { i18n } from "$lib/i18n";
 

--- a/apps/client/src/routes/styles.css
+++ b/apps/client/src/routes/styles.css
@@ -1,9 +1,6 @@
-@import '@fontsource/fira-mono';
-
 :root {
-	--font-body: Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
-		Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-	--font-mono: 'Fira Mono', monospace;
+	--font-body: "Noto Serif TC", sans-serif;
+	--font-mono: "Noto Sans Mono Variable", monospace;
 	--color-bg-0: rgb(202, 216, 228);
 	--color-bg-1: hsl(209, 36%, 86%);
 	--color-bg-2: hsl(224, 44%, 95%);
@@ -27,7 +24,12 @@ body {
 			rgba(255, 255, 255, 0.75) 0%,
 			rgba(255, 255, 255, 0) 100%
 		),
-		linear-gradient(180deg, var(--color-bg-0) 0%, var(--color-bg-1) 15%, var(--color-bg-2) 50%);
+		linear-gradient(
+			180deg,
+			var(--color-bg-0) 0%,
+			var(--color-bg-1) 15%,
+			var(--color-bg-2) 50%
+		);
 }
 
 h1,

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -36,6 +36,7 @@
 	},
 	"dependencies": {
 		"@astrojs/check": "0.5.2",
+		"@libs/asset": "workspace:*",
 		"astro": "4.3.5"
 	},
 	"devDependencies": {

--- a/apps/landing/src/layouts/Layout.astro
+++ b/apps/landing/src/layouts/Layout.astro
@@ -1,4 +1,8 @@
 ---
+import "@libs/asset/font/sans";
+import "@libs/asset/font/serif";
+import "@libs/asset/font/mono";
+
 import { languageTag } from "@libs/i18n/runtime";
 
 interface Props {
@@ -37,19 +41,11 @@ const { title } = Astro.props;
 		);
 	}
 	html {
-		font-family: system-ui, sans-serif;
+		font-family: "Noto Serif TC", sans-serif;
 		background: #13151a;
 		background-size: 224px;
 	}
 	code {
-		font-family:
-			Menlo,
-			Monaco,
-			Lucida Console,
-			Liberation Mono,
-			DejaVu Sans Mono,
-			Bitstream Vera Sans Mono,
-			Courier New,
-			monospace;
+		font-family: "Noto Sans Mono Variable", monospace;
 	}
 </style>

--- a/lefthook.toml
+++ b/lefthook.toml
@@ -1,7 +1,7 @@
 #:schema https://json.schemastore.org/lefthook.json
 
 [pre-commit.commands]
-biome = { glob = "*.{cjs,js,ts,d.ts,json,jsonc}", run = "pnpm biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}" }
+biome = { glob = "*.{js,ts,d.ts,json,jsonc}", run = "pnpm biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}" }
 inlang = { glob = "libs/i18n/src/messages/*.json", run = "pnpm lint:i18n" }
 markdownlint = { glob = "*.md", run = "pnpm markdownlint-cli2 {staged_files}" }
 prettier = { glob = "*.{astro,html,svelte}", run = "pnpm prettier --cache --cache-location node_modules/.cache/prettier --plugin prettier-plugin-astro --plugin prettier-plugin-svelte --list-different {staged_files}" }

--- a/libs/README.md
+++ b/libs/README.md
@@ -8,28 +8,30 @@
 ```text
 ../
 .
-├── [1] config
-├── [2] core
-├── [3] database
-├── [4] i18n
-├── [5] logger
-├── [6] path
-├── [7] token
-├── [9] unit
-├── [9] ui
-└── [10] util
+├── [1] asset
+├── [2] config
+├── [3] core
+├── [4] database
+├── [5] i18n
+├── [6] logger
+├── [7] path
+├── [8] token
+├── [10] unit
+├── [10] ui
+└── [11] util
 ```
 
 Where as:
 
 - [`../`](../README.md) - project workspace root
-- [`[1] config`](./config/README.md) -> `@libs/config` - project configuration
-- [`[2] core`](./core/README.md) -> `@libs/core` - fundamental structures
-- [`[3] database`](./database/README.md) -> `@libs/database` - database services
-- [`[5] i18n`](./i18n/README.md) -> `@libs/i18n` - translation messages
-- [`[6] logger`](./logger/README.md) -> `@libs/logger` - universal logger
-- [`[7] path`](./path/README.md) -> `@libs/path` - absolute paths
-- [`[7] token`](./token/README.md) -> `@libs/token` - Design tokens
-- [`[7] ui`](./ui/README.md) -> `@libs/ui` - modular UI components
-- [`[9] unit`](./unit/README.md) -> `@libs/unit` - smallest and modular units
-- [`[10] util`](./util/README.md) -> `@libs/util` - reusable snippets
+- [`[1] asset`](./asset/README.md) -> `@libs/asset` - shared assets
+- [`[2] config`](./config/README.md) -> `@libs/config` - project configuration
+- [`[3] core`](./core/README.md) -> `@libs/core` - fundamental structures
+- [`[4] database`](./database/README.md) -> `@libs/database` - database services
+- [`[6] i18n`](./i18n/README.md) -> `@libs/i18n` - translation messages
+- [`[7] logger`](./logger/README.md) -> `@libs/logger` - universal logger
+- [`[8] path`](./path/README.md) -> `@libs/path` - absolute paths
+- [`[8] token`](./token/README.md) -> `@libs/token` - Design tokens
+- [`[8] ui`](./ui/README.md) -> `@libs/ui` - modular UI components
+- [`[10] unit`](./unit/README.md) -> `@libs/unit` - smallest and modular units
+- [`[11] util`](./util/README.md) -> `@libs/util` - reusable snippets

--- a/libs/asset/README.md
+++ b/libs/asset/README.md
@@ -1,0 +1,3 @@
+# `@libs/asset`
+
+Shared graphical assets to be used in the project apps.

--- a/libs/asset/README.md
+++ b/libs/asset/README.md
@@ -1,3 +1,4 @@
 # `@libs/asset`
 
 Shared graphical assets to be used in the project apps.
+**The core purpose of this package is to maintain the single source of truth for the design system.**

--- a/libs/asset/package.json
+++ b/libs/asset/package.json
@@ -7,8 +7,14 @@
 	"engines": {
 		"node": ">=20"
 	},
+	"files": [
+		"/dist"
+	],
+	"exports": {
+		"./*": "./dist/*.js"
+	},
 	"scripts": {
-		"build": "",
+		"build": "tsc --project \"./tsconfig.build.json\" ",
 		"clean": "pnpm run \"/^clean:.*/\" ",
 		"clean:build": "del \"./dist\" ",
 		"clean:cache": "del \"./node_modules/.cache\" \"./.turbo\" ",
@@ -29,5 +35,10 @@
 		"lint:ts": "tsc --noEmit",
 		"lint:typos": "typos --verbose",
 		"test": "vitest run --dir \"./src\" --passWithNoTests --typecheck"
+	},
+	"dependencies": {
+		"@fontsource-variable/noto-sans-mono": "5.0.18",
+		"@fontsource-variable/noto-sans-tc": "5.0.4",
+		"@fontsource/noto-serif-tc": "5.0.11"
 	}
 }

--- a/libs/asset/package.json
+++ b/libs/asset/package.json
@@ -1,0 +1,33 @@
+{
+	"$schema": "https://json.schemastore.org/package",
+	"private": true,
+	"type": "module",
+	"name": "@libs/asset",
+	"version": "0.1.0",
+	"engines": {
+		"node": ">=20"
+	},
+	"scripts": {
+		"build": "",
+		"clean": "pnpm run \"/^clean:.*/\" ",
+		"clean:build": "del \"./dist\" ",
+		"clean:cache": "del \"./node_modules/.cache\" \"./.turbo\" ",
+		"clean:test": "del \"./coverage\" ",
+		"dev": "pnpm run \"/^dev:.*/\" ",
+		"dev:build": "",
+		"dev:doc": "typedoc --watch",
+		"dev:test": "pnpm vitest watch --dir \"./src\" --passWithNoTests --typecheck --ui --open=false",
+		"fix": "pnpm run \"/^fix:.*/\" ",
+		"fix:format": "biome format . --verbose --write",
+		"fix:js": "biome lint . --verbose --apply-unsafe",
+		"fix:md": "markdownlint-cli2 \"**/*.md\" \"#**/node_modules\" --fix",
+		"fix:typos": "typos --verbose --write-changes",
+		"lint": "pnpm run \"/^lint:.*/\" ",
+		"lint:format": "biome format . --verbose",
+		"lint:js": "biome lint . --verbose",
+		"lint:md": "markdownlint-cli2 \"**/*.md\" \"#**/node_modules\" ",
+		"lint:ts": "tsc --noEmit",
+		"lint:typos": "typos --verbose",
+		"test": "vitest run --dir \"./src\" --passWithNoTests --typecheck"
+	}
+}

--- a/libs/asset/src/font/mono.ts
+++ b/libs/asset/src/font/mono.ts
@@ -1,2 +1,8 @@
+/**
+ * `font-mono` source file from the design system.
+ * @see {@link https://fontsource.org/fonts/noto-sans-mono}
+ * @packageDocumentation
+ */
+
 /* @ts-ignore - NOTE: Workaround. No idea how to deal with lack of types from a package containing CSS files only. */
 export * from "@fontsource-variable/noto-sans-mono/wdth.css";

--- a/libs/asset/src/font/mono.ts
+++ b/libs/asset/src/font/mono.ts
@@ -1,0 +1,2 @@
+/* @ts-ignore - NOTE: Workaround. No idea how to deal with lack of types from a package containing CSS files only. */
+export * from "@fontsource-variable/noto-sans-mono/wdth.css";

--- a/libs/asset/src/font/sans.ts
+++ b/libs/asset/src/font/sans.ts
@@ -1,0 +1,2 @@
+/* @ts-ignore - NOTE: Workaround. No idea how to deal with lack of types from a package containing CSS files only. */
+export * from "@fontsource-variable/noto-sans-tc";

--- a/libs/asset/src/font/sans.ts
+++ b/libs/asset/src/font/sans.ts
@@ -1,2 +1,8 @@
+/**
+ * `font-sans` source file from the design system.
+ * @see {@link https://fontsource.org/fonts/noto-sans-tc}
+ * @packageDocumentation
+ */
+
 /* @ts-ignore - NOTE: Workaround. No idea how to deal with lack of types from a package containing CSS files only. */
 export * from "@fontsource-variable/noto-sans-tc";

--- a/libs/asset/src/font/serif.ts
+++ b/libs/asset/src/font/serif.ts
@@ -1,0 +1,8 @@
+/* @ts-ignore - NOTE: Workaround. No idea how to deal with lack of types from a package containing CSS files only. */
+export * from "@fontsource/noto-serif-tc/300.css";
+/* @ts-ignore - NOTE: Workaround. No idea how to deal with lack of types from a package containing CSS files only. */
+export * from "@fontsource/noto-serif-tc/500.css";
+/* @ts-ignore - NOTE: Workaround. No idea how to deal with lack of types from a package containing CSS files only. */
+export * from "@fontsource/noto-serif-tc/700.css";
+/* @ts-ignore - NOTE: Workaround. No idea how to deal with lack of types from a package containing CSS files only. */
+export * from "@fontsource/noto-serif-tc/900.css";

--- a/libs/asset/src/font/serif.ts
+++ b/libs/asset/src/font/serif.ts
@@ -1,3 +1,9 @@
+/**
+ * `font-sans` source file from the design system.
+ * @see {@link https://fontsource.org/fonts/noto-serif-tc}
+ * @packageDocumentation
+ */
+
 /* @ts-ignore - NOTE: Workaround. No idea how to deal with lack of types from a package containing CSS files only. */
 export * from "@fontsource/noto-serif-tc/300.css";
 /* @ts-ignore - NOTE: Workaround. No idea how to deal with lack of types from a package containing CSS files only. */

--- a/libs/asset/tsconfig.build.json
+++ b/libs/asset/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "dist/",
+		"rootDir": "src/"
+	},
+	"exclude": ["src/**/*.test.ts", "scripts/"],
+	"include": ["src/"]
+}

--- a/libs/asset/tsconfig.json
+++ b/libs/asset/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo",
+	},
+	"include": ["../../types/*.d.ts", "src/"],
+}

--- a/libs/asset/typedoc.json
+++ b/libs/asset/typedoc.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"extends": ["../../typedoc.base.json"],
+	"entryPoints": ["src/**/*.ts"]
+}

--- a/libs/asset/vitest.config.ts
+++ b/libs/asset/vitest.config.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+	test: {
+		environment: "node",
+	},
+});

--- a/libs/path/src/lib.gen.ts
+++ b/libs/path/src/lib.gen.ts
@@ -8,6 +8,7 @@
  */
 export const WORKSPACE_LIBS = [
 	// biome ignore-format: Easier to read, even if the list is short
+	"asset",
 	"config",
 	"core",
 	"database",

--- a/libs/token/src/typography/font.ts
+++ b/libs/token/src/typography/font.ts
@@ -7,7 +7,7 @@ import { FontWeight } from "./font-weight.js";
  */
 export const FONT = {
 	mono: {
-		family: new FontFamily("mono", "Noto Sans Mono"),
+		family: new FontFamily("mono", "Noto Sans Mono Variable"),
 		weight: {
 			regular: new FontWeight("mono", "regular", 400),
 			bold: new FontWeight("mono", "bold", 700),
@@ -15,7 +15,7 @@ export const FONT = {
 	},
 
 	sans: {
-		family: new FontFamily("sans", "Noto Sans TC"),
+		family: new FontFamily("sans", "Noto Sans TC Variable"),
 		weight: {
 			light: new FontWeight("sans", "light", 300),
 			medium: new FontWeight("sans", "medium", 500),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,8 @@ importers:
         specifier: workspace:*
         version: link:../../libs/i18n
 
+  libs/asset: {}
+
   libs/config:
     dependencies:
       '@libs/logger':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,9 +195,6 @@ importers:
         specifier: workspace:*
         version: link:../../libs/i18n
     devDependencies:
-      '@fontsource/fira-mono':
-        specifier: 5.0.8
-        version: 5.0.8
       '@inlang/paraglide-js-adapter-sveltekit':
         specifier: 0.4.1
         version: 0.4.1(@sveltejs/kit@2.5.0)
@@ -216,6 +213,9 @@ importers:
       '@astrojs/check':
         specifier: 0.5.2
         version: 0.5.2(prettier@3.2.5)(typescript@5.3.3)
+      '@libs/asset':
+        specifier: workspace:*
+        version: link:../../libs/asset
       astro:
         specifier: 4.3.5
         version: 4.3.5(@types/node@20.11.16)(typescript@5.3.3)
@@ -2870,10 +2870,6 @@ packages:
   /@fontsource-variable/noto-sans-tc@5.0.4:
     resolution: {integrity: sha512-VWQE0FUjm3J8kwQV0isoQbmijD8SBZsQbwNf+YTrfbIEVA4PdHF/JZXHuSaCEd6l7GnP6Q15IorEHEMCaWHkzg==}
     dev: false
-
-  /@fontsource/fira-mono@5.0.8:
-    resolution: {integrity: sha512-8OJiUK2lzJjvDlkmamEfhtpL1cyFApg1Pk4kE5Pw5UTf1ETF3Yy/pprgwV5I+LQPDjuFvinsinT9xSUZ2b/zuQ==}
-    dev: true
 
   /@fontsource/noto-serif-tc@5.0.11:
     resolution: {integrity: sha512-+h4mfrojI81bC256H/Yghdn9+h4nux15bTkOfUjHxj37NkhgY7UVM8U3NgXwDudbcWwMmaUGTe2W0/hQODMeOw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
 
   apps/client:
     dependencies:
+      '@libs/asset':
+        specifier: workspace:*
+        version: link:../../libs/asset
       '@libs/i18n':
         specifier: workspace:*
         version: link:../../libs/i18n
@@ -224,7 +227,17 @@ importers:
         specifier: workspace:*
         version: link:../../libs/i18n
 
-  libs/asset: {}
+  libs/asset:
+    dependencies:
+      '@fontsource-variable/noto-sans-mono':
+        specifier: 5.0.18
+        version: 5.0.18
+      '@fontsource-variable/noto-sans-tc':
+        specifier: 5.0.4
+        version: 5.0.4
+      '@fontsource/noto-serif-tc':
+        specifier: 5.0.11
+        version: 5.0.11
 
   libs/config:
     dependencies:
@@ -2850,9 +2863,21 @@ packages:
     dev: false
     optional: true
 
+  /@fontsource-variable/noto-sans-mono@5.0.18:
+    resolution: {integrity: sha512-bMDYkZJLyIzl5ENzFX+HY1phM6jgHUDbtvgKtIePRIXcYC0cvvNfqPAoUNP80/swxT3HTE3dx6iO9ftw5BnAyQ==}
+    dev: false
+
+  /@fontsource-variable/noto-sans-tc@5.0.4:
+    resolution: {integrity: sha512-VWQE0FUjm3J8kwQV0isoQbmijD8SBZsQbwNf+YTrfbIEVA4PdHF/JZXHuSaCEd6l7GnP6Q15IorEHEMCaWHkzg==}
+    dev: false
+
   /@fontsource/fira-mono@5.0.8:
     resolution: {integrity: sha512-8OJiUK2lzJjvDlkmamEfhtpL1cyFApg1Pk4kE5Pw5UTf1ETF3Yy/pprgwV5I+LQPDjuFvinsinT9xSUZ2b/zuQ==}
     dev: true
+
+  /@fontsource/noto-serif-tc@5.0.11:
+    resolution: {integrity: sha512-+h4mfrojI81bC256H/Yghdn9+h4nux15bTkOfUjHxj37NkhgY7UVM8U3NgXwDudbcWwMmaUGTe2W0/hQODMeOw==}
+    dev: false
 
   /@humanwhocodes/config-array@0.9.5:
     resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -34,6 +34,13 @@ const config = defineWorkspace([
 	},
 	// Libraries
 	{
+		extends: resolve(__dirname, "libs", "asset", "vitest.config.ts"),
+		test: {
+			include: [resolve(__dirname, "libs", "asset", "src", "**", "*.test.ts")],
+			name: "@libs/asset",
+		},
+	},
+	{
 		extends: resolve(__dirname, "libs", "config", "vitest.config.ts"),
 		test: {
 			include: [resolve(__dirname, "libs", "config", "src", "**", "*.test.ts")],


### PR DESCRIPTION
## Description

- Add root for `@libs/asset`
- Add initial package modules for fonts
- Implement font assets on `@apps/client`
- Implement on `apps\landing`
- Document modules
- inject into Storybook
- Update font names to align with asset
